### PR TITLE
Force umount of aws-ami tmp build path

### DIFF
--- a/create-ami.sh
+++ b/create-ami.sh
@@ -209,7 +209,7 @@ EOF
 	doas umount ${_MNT}/var
 	doas umount ${_MNT}/home
 	doas umount ${_MNT}/tmp
-	doas umount ${_MNT}
+	doas umount -f ${_MNT}
 	doas vnconfig -u ${_VNDEV}
 
 	pr_action "image available at: ${_IMG}"


### PR DESCRIPTION
On my workstation this will not unmount without `-f`

    $ doas fuser -c /home/eradman/iso/aws-ami.nBkG9TaL2R/mnt
    /home/eradman/iso/aws-ami.nBkG9TaL2R/mnt:
    
    $ doas umount /home/eradman/iso/aws-ami.nBkG9TaL2R/mnt
    umount: /home/eradman/iso/aws-ami.nBkG9TaL2R/mnt: Device busy
