### PR TITLE
Reintroduce AWS_AZ variable

### DIFF
--- a/create-ami.sh
+++ b/create-ami.sh
@@ -23,6 +23,7 @@ umask 022
 AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:=${AWS_ACCESS_KEY}}
 AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:=${AWS_SECRET_KEY}}
 AWS_REGION=${AWS_REGION:=eu-west-1}
+AWS_AZ=${AWS_AZ:=${AWS_REGION}a}
 
 MIRROR=${MIRROR:=https://mirrors.evowise.com/pub/OpenBSD}
 
@@ -201,7 +202,7 @@ create_ami() {
 		${_VMDK} \
 		-f vmdk \
 		--region ${AWS_REGION} \
-		-z ${AWS_REGION}a \
+		-z ${AWS_AZ} \
 		-d ${_IMGNAME} \
 		-O "${AWS_ACCESS_KEY_ID}" \
 		-W "${AWS_SECRET_ACCESS_KEY}" \


### PR DESCRIPTION
Some AWS availability zones do not have an "a" or a "b" so it's hard to
make assumptions about the zone name.

Client.InvalidParameterValue: Invalid value 'us-west-1a' for AvailabilityZone.
(Service: AmazonEC2; Status Code: 400; Error Code: InvalidParameterValue; Request ID: 87b150d9-4789-4d9d-bb51-3e8f31a43e17)