### PR TITLE
More reliable way to get Volume ID

### DIFF
--- a/create-ami.sh
+++ b/create-ami.sh
@@ -169,6 +169,11 @@ create_img() {
 	pr_action "image available at: ${_IMG}"
 }
 
+volume_ids() {
+	aws --output json ec2 describe-conversion-tasks | \
+	python2.7 -c 'from __future__ import print_function;import sys,json; [print(task["ImportVolume"]["Volume"]["Id"]) if "Id" in task["ImportVolume"]["Volume"] else None for task in json.load(sys.stdin)["ConversionTasks"]]'
+}
+
 create_ami() {
 	local _IMGNAME=${_IMG##*/}
 	local _BUCKETNAME=${_IMGNAME}
@@ -191,7 +196,8 @@ create_ami() {
 	vmdktool -v ${_VMDK} ${_IMG}
 
 	pr_action "uploading image to S3 and converting to volume in region ${AWS_REGION}"
-	ec2-import-volume \
+	VOLIDS="$(volume_ids)"
+		ec2-import-volume \
 		${_VMDK} \
 		-f vmdk \
 		--region ${AWS_REGION} \
@@ -203,18 +209,13 @@ create_ami() {
 		-w "${AWS_SECRET_ACCESS_KEY}" \
 		-b ${_BUCKETNAME}
 
+	VOLIDS_NEW="$(volume_ids)"
 	echo
-	while [[ -z ${_VOL} ]]; do
-		_VOL=$(ec2-describe-conversion-tasks \
-			-O "${AWS_ACCESS_KEY_ID}" \
-			-W "${AWS_SECRET_ACCESS_KEY}" \
-			--region ${AWS_REGION} 2>/dev/null |
-			grep "${_IMGNAME}" |
-			grep -Eo "vol-[[:alnum:]]*") || true
+	while [[ "$VOLIDS" = "$VOLIDS_NEW" ]]; do
 		sleep 10
+		VOLIDS_NEW="$(volume_ids)"
 	done
-
-	# XXX
+	_VOL=$(for v in $VOLIDS_NEW; do echo "$VOLIDS"|fgrep -q $v || echo $v;done)
 	#echo
 	#echo "deleting local and remote disk images"
 	#rm -rf ${_WRKDIR}


### PR DESCRIPTION
Previously the script would fail to create an AMI if there were multiple Import Volume tasks in the history, because it would retrieve the wrong VolumeId.
The proposed change introduces a function that uses awscli instead of ec2-api-tools to get the json information, passing through a python one liner to get the list of volume IDs.  This function is used in the loop where the status of import volume is checked before the script continues.