### PR TITLE
fix $v to $_v

### DIFF
--- a/create-ami.sh
+++ b/create-ami.sh
@@ -216,8 +216,8 @@ create_ami() {
 		sleep 10
 		_VOLIDS_NEW="$(volume_ids)"
 	done
-	_VOL=$(for _v in ${_VOLIDS_NEW}; do echo "${_VOLIDS}" | fgrep -q $v ||
-		echo $v; done)
+	_VOL=$(for _v in ${_VOLIDS_NEW}; do echo "${_VOLIDS}" | fgrep -q $_v ||
+		echo $_v; done)
 
 	# XXX
 	#echo


### PR DESCRIPTION
otherwise the following error

usage: fgrep [-abcEFGHhIiLlnoqRsUVvwxZ] [-A num] [-B num] [-C[num]]
        [-e pattern] [-f file] [--binary-files=value] [--context[=num]]
        [--line-buffered] [pattern] [file ...]
=========================================================================
| creating snapshot in region eu-central-1
=========================================================================
Required parameter 'VOLUME' missing (-h for usage)