### PR TITLE
when chroot, ignore environment variables

### DIFF
--- a/create-ami.sh
+++ b/create-ami.sh
@@ -146,10 +146,10 @@ create_img() {
 	echo "127.0.0.1\tlocalhost" >${_MNT}/etc/hosts
 	echo "::1\t\tlocalhost" >>${_MNT}/etc/hosts
 	sed -i "s/^#\(PermitRootLogin\) .*/\1 no/" ${_MNT}/etc/ssh/sshd_config
-	chroot ${_MNT} ln -sf /usr/share/zoneinfo/UTC /etc/localtime
-	chroot ${_MNT} ldconfig /usr/local/lib /usr/X11R6/lib
-	chroot ${_MNT} rcctl disable sndiod
-	chroot ${_MNT} useradd -G wheel -L staff -c 'EC2 Default User' -g =uid \
+	env -i chroot ${_MNT} ln -sf /usr/share/zoneinfo/UTC /etc/localtime
+	env -i chroot ${_MNT} ldconfig /usr/local/lib /usr/X11R6/lib
+	env -i chroot ${_MNT} rcctl disable sndiod
+	env -i chroot ${_MNT} useradd -G wheel -L staff -c 'EC2 Default User' -g =uid \
 		-m -u 1000 ec2-user
 	echo "permit nopass ec2-user" >${_MNT}/etc/doas.conf
 	echo "ec2-user" >${_MNT}/root/.forward
@@ -158,7 +158,7 @@ create_img() {
 	sha256 ${_MNT}/bsd | (umask 077; sed "s,${_MNT},," \
 		>${_MNT}/var/db/kernel.SHA256)
 	if [[ -x ${_MNT}/usr/libexec/reorder_kernel ]]; then
-		chroot ${_MNT} /usr/libexec/reorder_kernel
+		env -i chroot ${_MNT} /usr/libexec/reorder_kernel
 	fi
 
 	pr_action "unmounting the image"


### PR DESCRIPTION
such as TMPDIR. fixes rcctl failure when TMPDIR is set.