### PR TITLE
Extract vnd devices from vnconfig

### DIFF
--- a/obsd-img-builder.sh
+++ b/obsd-img-builder.sh
@@ -187,8 +187,12 @@ create_img()
 	pr_title "creating modified bsd.rd for autoinstall"
 	ftp -MV -o ${_bsdrd} ${MIRROR}/${RELEASE}/${ARCH}/bsd.rd
 	rdsetroot -x ${_bsdrd} ${_rdextract}
-	_vndev=$(vnconfig ${_rdextract})
-	install -d ${_rdmnt}
+
+  _vndev="$(vnconfig -l | grep 'not in use' | head -1 | cut -d: -f1)"
+	#_vndev=$(vnconfig ${_rdextract})
+	vnconfig "${_vndev}" "${_rdextract}"
+
+  install -d ${_rdmnt}
 	mount /dev/${_vndev}a ${_rdmnt}
 	cp ${_WRKDIR}/auto_install.conf ${_rdmnt}
 	umount ${_rdmnt}
@@ -247,9 +251,16 @@ create_install_site_disk()
 
 	pr_title "creating sd1 and storing siteXX.tgz"
 
+ 
 	vmctl create ${_siteimg} -s 1G
-	_vndev="$(vnconfig ${_siteimg})"
-	fdisk -iy ${_vndev}
+
+
+#  _vndev="$(vnconfig ${_siteimg})"
+
+  _vndev="$(vnconfig -l | grep 'not in use' | head -1 | cut -d: -f1)"
+  vnconfig "${_vndev}" "${_siteimg}"
+
+  fdisk -iy ${_vndev}
 	echo "a a\n\n\n\nw\nq\n" | disklabel -E ${_vndev}
 	newfs ${_vndev}a
 


### PR DESCRIPTION
The original code called vnconfig with just the image filename to load;
vnconfig was throwing an error (fresh install of OpenBSD6.5) asserting
that two parametes were required vnd_dev and image which were the vnd
device and image filename, respectively.  Therefore, to acquire the
vnd device, I used vnconfig -l to list the devices in-use, grepped
out the 'not in use' lines, grabbed the first one of them, and
extracted the vnd device from there.  As both instances of vnconfig
used _vndev to store the vnd device, I captured the output from the
aforementioned and passed it to vnconfig which seems to work.
Unfortunately, the installer panics later on when it's unable to
acquire the sets using https and the autoinstall response requires the
installer to not fallback to http.  That's.... another problem for
another day.

The error message is:

Unable to connect using https. Use http instead? [no] no